### PR TITLE
2467. 용액

### DIFF
--- a/BOJ_JAVA/src/Main_2467.java
+++ b/BOJ_JAVA/src/Main_2467.java
@@ -1,0 +1,46 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main_2467 {
+    static int[] number;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int N = Integer.parseInt(br.readLine());
+        number = new int[N];
+
+        st = new StringTokenizer(br.readLine());
+        for (int n = 0; n < N; n++)
+            number[n] = Integer.parseInt(st.nextToken());
+
+        long result = 2000000000;
+        int resultS = 0;
+        int resultE = N-1;
+
+        int start = resultS;
+        int end = resultE;
+        while(start != end){
+            int sNum = number[start];
+            int eNum = number[end];
+
+            long tmp = sNum + eNum;
+            if (Math.abs(tmp) < result){
+                result = Math.abs(tmp);
+                resultS = start;
+                resultE = end;
+            }
+
+            if (tmp == 0)
+                break;
+            else if (tmp > 0)
+                end--;
+            else if (tmp < 0)
+                start++;
+        }
+
+        System.out.println(number[resultS] + " " + number[resultE]);
+    }
+}


### PR DESCRIPTION
## 문제 및 유형
https://www.acmicpc.net/problem/2467

Two Pointer, Binary Search

## 풀이
입력은 2개 이상 100,000개 이하의 수열로 이루어져있으며
-1,000,000,000 이상 1,000,000,000 이하 범위의 서로 다른 수가 오름차순으로 주어진다.
또한, 모든 입력이 음수일수도, 양수일수도 있다.

해당문제는 두개의 포인터를 사용하여 합이 0에 가장 가까운 두 수를 찾아내면된다.
1. 두 포인터에 위치한 수의 합의 절대값을 비교하여 필요시 갱신
2. 두 포인터에 위치한 수의 합을 0과 비교하여 start 혹은 end 조정

우선, start, end 두개의 포인터는 수열의 0번 인덱스와 N-1번 인덱스에서 시작한다.

start와 end 가 다른곳을 가리키는 동안 아래 과정을 반복한다.
1. 현재 |arr[start] + arr[end]| 이 기존에 구해진 합의 절대값보다 작다면 (== 0에 가깝다면) 결과 start, end, 새로운 절대값을 갱신한다.

2. 현재 |arr[start] - arr[end]| 의 갱신 여부와 상관없이 
두 수의 합이 음수라면 : 합이 커져야 하므로 음수 포인터가 0쪽으로 이동 -> start 증가
두 수의 합이 양수라면 : 합이 작아져야 하므로 양수 포인터가 0쪽으로 이동 -> end 감소
만약 두 수의 합이 0이라면 : 아무거나 출력하면 되므로 종료

## 기록
start 와 end 의 증가, 감소 조건을 잘 생각하면 쉽게 풀 수 있다.
완탐은 O(n^n) 이므로 해결 불가.