### PR TITLE
16234 : 인구이동

### DIFF
--- a/BOJ_JAVA/src/Main_16234.java
+++ b/BOJ_JAVA/src/Main_16234.java
@@ -1,0 +1,98 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+class Pos{
+    int x;
+    int y;
+    public Pos(int x, int y){
+        this.x = x;
+        this.y = y;
+    }
+}
+
+public class Main_16234 {
+    static int[][] graph;
+    static boolean[][] visited;
+    static int N, L, R;
+    static boolean flag = false;                                // 하루동안 연합이 한번이라도 이뤄졌으면 true
+    static Queue<Pos> nextQ = new LinkedList<>();               // 현재 연합이 아니라서 다시 체크할 queue
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        L = Integer.parseInt(st.nextToken());
+        R = Integer.parseInt(st.nextToken());
+
+        graph = new int[N][N];
+        visited = new boolean[N][N];
+        for (int n = 0; n < N; n++){                    // 나라별 인구수 받기
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++)
+                graph[n][j] = Integer.parseInt(st.nextToken());
+        }
+
+        Queue<Pos> currQ = new LinkedList<>();               // bfs 수행할 queue
+        currQ.add(new Pos(0, 0));
+        int day = 0;
+        while(true){
+            BFS(currQ);                         // BFS -> 나라별로 연합인 나라 체크해서 인구수 업데이트
+            if (nextQ.isEmpty()){                   // 하루동안 모든 나라 국경 탐색이 끝났으면
+                if (!flag)                          // 연합 성사 여부 체크
+                    break;
+                day++;                              // 연합이 한번이라도 이뤄졌으면 하루 추가
+                nextQ.add(new Pos(0, 0));     // 0, 0 나라 큐에 추가
+                for (boolean[] arr : visited)       // 방문배열 초기화
+                    Arrays.fill(arr, false);
+                flag = false;                       // 연합 여부 플래그 초기화
+            }
+            currQ.add(nextQ.poll());            // 연합을 알아보지 않은 다음 나라 탐색
+        }
+
+        System.out.println(day);
+    }
+
+    static void BFS(Queue<Pos> currQ) {
+        int[] xList = {-1, 0, 1, 0};
+        int[] yList = {0, 1, 0, -1};
+
+        int unionSum = 0;
+        Queue<Pos> union = new LinkedList<>();
+        while (!currQ.isEmpty()) {
+            Pos now = currQ.poll();
+            if (visited[now.x][now.y])                  // 이미 연합이 이뤄진 나라라면 패스
+                continue;
+            unionSum += graph[now.x][now.y];            // 연합 인구수에 더해줌
+            union.add(now);                             // 현재 연합인 나라 큐에 추가
+            visited[now.x][now.y] = true;               // 방문체크
+            for (int k = 0; k < 4; k++) {
+                int nx = now.x + xList[k];
+                int ny = now.y + yList[k];
+                if ((nx >= 0 && nx < N) && (ny >= 0 && ny < N)) {       // 범위 체크
+                    if (!visited[nx][ny]) {                          // 방문하지 않았으면
+                        int diff = Math.abs(graph[now.x][now.y] - graph[nx][ny]);               // 인구 수 차이 체크
+                        if (diff >= L && diff <= R)
+                            currQ.add(new Pos(nx, ny));         // 인구차가 범위내에 있으면 queue에 추가
+                        else          // 인구차가 범위내에 없으면 nextQ에 삽입
+                            nextQ.add(new Pos(nx, ny));
+                    }
+                }
+            }
+        }
+        // 인구이동
+        if (union.size() > 1) {
+            flag = true;
+            int unionResult = unionSum / union.size();
+            while(!union.isEmpty()){
+                Pos p = union.poll();
+                graph[p.x][p.y] = unionResult;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제 및 유형
https://www.acmicpc.net/problem/16234

BFS
## 풀이
모든 나라를 BFS로 순회하며 연합이라고 판단되면 인구수를 갱신한다.
해당 풀이에서 BFS -> 하나의 연합 체크이다.

우선, 2차원 배열에 인구수를 저장한다.
[0][0] 칸부터 시작하여 BFS 를 수행한다.

이 때, 두개의 queue 를 선언한다.
- currQ : 현재 연합을 확인할 나라가 들어간 큐 (empty -> nextQ 에서 꺼내기)
- nextQ : 오늘 연합확인을 하지 않은 나라가 들어간 큐 (empty -> day 증가)

currQ 를 BFS 에 전달하여 BFS 를 수행한다.
BFS 함수에서는 해당 BFS 에서 연합이 이뤄질 나라를 넣어둘 union queue 를 선언하고,
해당 연합국들의 총 인구수를 저장할 변수를 선언한다.

currQ 에서 나라를 하나씩 꺼내면서 다음 조건이 부합하면 currQ에 삽입한다.
- 오늘 연합이 이뤄지지 않은 나라 (visited 배열로 체크)
- 연합 조건을 충족하는 나라

조건이 부합하면 union queue 에 삽입한다. 또한 해당 나라의 인구수를 총 인구수에 더한다.
연합이 이뤄지지 않았지만, 연합 조건을 충족하지 않는 나라는 nextQ 에 삽입한다.

BFS 가 끝나면 최종인구수 / union queue 의 size 를 구한 뒤,
union queue 에서 하나씩 꺼내어 인구수 변경 -> 연합처리 (visited true) 한다.

main 으로 돌아간 뒤 nextQ를 currQ 로 변경하여 연합을 처리하고
만약 nextQ 가 비었다면 모든 나라가 연합 확인을 진행했다는 의미이므로
- 해당 일에 진행된 연합의 횟수가 1 이상이라면 day 증가.
- 한번도 연합이 이뤄지지 않았다면 프로그램을 종료.

## 기록
- currQ 를 따로 두지 않고 nextQ에서 꺼내어 BFS 호출 -> BFS 내부에서 currQ 를 선언하는게 더 나을 것 같다.
- 연합이 이뤄지지 않았음을 확인했다고 visited -> true 하면 안된다. (현재 국가의 연합국 탐색시에 조건을 만족시킬 수 있기 때문)
즉, visited 배열 == 연합 성사 배열이다.
