### PR TITLE
7682. 틱택토

### DIFF
--- a/BOJ_JAVA/src/Main_7682.java
+++ b/BOJ_JAVA/src/Main_7682.java
@@ -1,0 +1,113 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main_7682 {
+    static final String valid = "valid";
+    static final String invalid = "invalid";
+    static char[][] board = new char[3][3];
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        while (true){
+            String str = br.readLine();
+            if (str.equals("end"))
+                break;
+
+            int xCnt = 0;
+            int oCnt = 0;
+            // 게임판 받기
+            for (int i = 0; i < 3; i++){
+                char[] tmp = str.substring(i*3, i*3+3).toCharArray();
+                board[i] = tmp;
+                for (int j = 0; j < 3; j++){
+                    switch (board[i][j]){
+                        case 'X':
+                            xCnt++;
+                            break;
+                        case 'O':
+                            oCnt++;
+                            break;
+                    }
+                }
+            }
+
+            // 말 개수로 1차 확인
+            if ((xCnt < oCnt) ||(xCnt-oCnt > 1)){           // x >= o 이고 x-o > 1 이 아니면 실패
+                System.out.println(invalid);
+                continue;
+            }
+
+            // 우승 여부 확인
+            boolean xWin = checkWin('X');
+            if (xWin && (xCnt == oCnt)){      // x 가 이겼는데 x와 o의 개수가 같으면 실페
+                System.out.println(invalid);
+                continue;
+            }
+
+            boolean oWin = checkWin('O');
+            if(xWin && oWin){               // x o 둘 다 우승이면 실패
+                System.out.println(invalid);
+                continue;
+            }
+
+            if (oWin && (xCnt != oCnt)){        // o가 이겼는데 x 의 말이 1개 더 많으면 실패
+                System.out.println(invalid);
+                continue;
+            }
+
+            if(!xWin && !oWin && (xCnt+oCnt != 9)) {        // 우승이 없는데 말이 다 차지 않았음면 실패
+                System.out.println(invalid);
+                continue;
+            }
+
+            System.out.println(valid);
+        }
+    }
+
+    static boolean checkWin(char piece){
+        // win : true
+
+        int tmpCnt;
+        // 가로 확인
+        for (int i = 0; i < 3; i++){
+            tmpCnt = 0;
+            for (int j = 0; j < 3; j++){
+                if (board[i][j] == piece)
+                    tmpCnt++;
+            }
+            if (tmpCnt == 3)
+                return true;
+        }
+
+        // 세로 확인
+        for (int j = 0; j < 3; j++){
+            tmpCnt = 0;
+            for (int i = 0; i < 3; i++){
+                if (board[i][j] == piece)
+                    tmpCnt++;
+            }
+            if (tmpCnt == 3)
+                return true;
+        }
+
+        // 대각선 확인
+        tmpCnt = 0;
+        for (int i = 0; i < 3; i++){
+            if (board[i][i] == piece)
+                tmpCnt++;
+        }
+        if (tmpCnt == 3)
+            return true;
+
+        tmpCnt = 0;
+        int j = 2;
+        for (int i = 0; i < 3; i++){
+            if (board[i][j--] == piece)
+                tmpCnt++;
+        }
+        if (tmpCnt == 3)
+            return true;
+
+        return false;
+    }
+}


### PR DESCRIPTION
## 문제 및 유형
https://www.acmicpc.net/problem/7682

Implement
## 풀이
틱택토 게임의 규칙은 다음과 같다
1. 게임판은 3x3 크기이다.
2. X 와 O 는 반드시 번갈아가며 놓을 수 있다.
3. X 가 항상 첫번째이다.
4. 어느 때이든지 한 말이 가로 or 세로 or 대각선 방향으로 3칸을 놓으면 게임이 끝난다.
5. 승리자가 없어도 게임판이 가득 차면 게임이 끝난다.

위 규칙을 확인하여 입력된 게임판의 최종 상태가 올바르게 끝났는지 판별한다.

게임 상태 입력은 XX00XX.XX 와 같이 9 길이의 한줄 스트링으로 주어지며, X, O, . 만으로 구성된다. (.은 빈칸)
- 1번 조건은 항상 성립되니 판별하지 않는다.
- 2, 3번의 규칙은 게임 상태를 입력받아 3x3 크기의 2차원 배열에 저장하면서 확인한다.
X 가 항상 첫번째이므로 X와 O의 개수가 같거나, X가 O보다 1개 많은 상황만 허용된다.
따라서, 배열에 저장하며 각 말의 수를 체크하여 1차적으로 판별한다.
- 4번 규칙은 우승 여부와 말 개수의 여부로 확인한다.
X 말이 이긴 경우 X의 개수는 O의 개수보다 1개 많은 경우만 인정된다.
O 말이 이긴 경우 X와 O의 개수는 같아야만 한다.
X, O 둘 다 이기는 경우는 존재하지 않는다.
2차원 배열을 순회하며 우승 여부를 확인하고, 둘 중 하나만 우승했을 경우에 개수 조건을 확인하여 결과를 판별한다.
- 5번 규칙은 4번 판별 이후 둘 다 우승하지 않았을 경우 전체 말 개수의 합이 9인지 확인한다.

## 기록
Valid 판별보다 Invalid 판별을 하는것이 더 효율적이고 깔끔하다.