### PR TITLE
solve : Union Find

### DIFF
--- a/BOJ_JAVA/src/Main_1717.java
+++ b/BOJ_JAVA/src/Main_1717.java
@@ -1,0 +1,69 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main_1717 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        int[] arr = new int[N+1];                   // 각 집합의 루트 저장할 배열
+        for (int n = 0; n <= N; n++)                // 각 집합의 루트를 자기 자신으로
+            arr[n] = n;
+
+        for (int m = 0; m < M; m++){
+            st = new StringTokenizer(br.readLine());
+            int operator = Integer.parseInt(st.nextToken());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            switch (operator){
+                case 0:         // 합집합 만들기
+                    union(arr, a, b);
+                    break;
+
+                case 1:         // 같은 집합인지 확인하기
+                    int aParent = find(arr, a);
+                    int bParent = find(arr, b);
+                    if (aParent == bParent)
+                        System.out.println("YES");
+                    else
+                        System.out.println("NO");
+                    break;
+            }
+        }
+    }
+
+    static void union(int[] arr, int a, int b){
+        // 각 집합의 루트 찾기
+        int aParent = find(arr, a);
+        int bParent = find(arr, b);
+        if (aParent != bParent) {
+            if (aParent < bParent) {
+                arr[bParent] = aParent;
+                arr[b] = aParent;
+            }else {
+                arr[aParent] = bParent;
+                arr[a] = bParent;
+            }
+        }
+    }
+    static int find(int[] arr, int num){
+        int prev = num;
+        int parent = arr[num];
+        while(true){
+            if (arr[parent] == parent)
+                break;
+            parent = arr[parent];
+            arr[prev] = parent;
+            prev = parent;
+
+        }
+        return parent;
+    }
+}


### PR DESCRIPTION
## 문제 및 유형
https://www.acmicpc.net/problem/1717

Union Find
## 풀이
N 이 주어지고, 0부터 N까지의 집합이 존재한다.
m개의 줄에 걸쳐 주어지는 원소가 포함된 집합을 합치거나, 두 원소가 같은 집합에 있는지 확인한다.

예를들어,
0 1 2 가 주어지면, 1 이 포함된 집합과 2 가 포함된 집합을 합치고
1 1 2 가 주어지면, 1과 2가 같은 집합인지 확인한다.

우선, 1 ~ N 까지 부모를 저장할 배열을 선언한다.
이 때, **집합이 구성될 시 더 작은 수가 부모이다.**

0 명령어가 주어지면 두 수의 집합을 합친다.
- find 함수를 호출하여 각 수 집합의 루트를 찾는다.
- 더 큰 루트의 부모를 더 작은 루트로 바꾼다. 

1 명령어가 주어지면 두 수의 루트를 확인한다.
- parent[n] == n 이면 n이 집합의 루트이다.
- parent[n] != n 이면 n은 루트가 아니다.
따라서, n = parent[n] 으로 바뀌고 다시 루트인지 판별한다.
**이 때, n의 부모를 parent[parent[n]] 으로 갱신하여 압축한다.**

두 수의 루트가 같은지 판별한다.

## 기록
- n의 범위가 1,000,000 이하이기 때문에 최악의 경우 압축하지 않으면 시간초과가 나는 문제이다. 