### PR TITLE
18352. 특정 거리의 도시 찾기

### DIFF
--- a/BOJ_JAVA/src/Main_18352.java
+++ b/BOJ_JAVA/src/Main_18352.java
@@ -1,0 +1,70 @@
+import java.io.*;
+import java.util.*;
+
+public class Main_18352 {
+    static ArrayList<ArrayList<Integer>> graph = new ArrayList<>();
+    static int[] distance;
+    static boolean[] visited;
+    static int INF = 10000000;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());       // 노드 개수
+        int M = Integer.parseInt(st.nextToken());       // 간선 개수
+        int K = Integer.parseInt(st.nextToken());       // 요구 최단 거리
+        int X = Integer.parseInt(st.nextToken());       // 출발 도시 번호
+
+        distance = new int[N+1];            // 노드에 도달하는데 걸리는 최단 거리 저장할 배열
+        visited = new boolean[N+1];         // 방문 체크 배열
+        Arrays.fill(distance, INF);         // 무한대로 설정
+        distance[X] = 0;                    // 출발노드 0으로 설정
+
+        for (int n = 0; n <= N; n++)
+            graph.add(n, new ArrayList<>());
+
+        // 간선 정보 받음 (a, b : a->b)
+        for(int m = 0; m < M; m++){
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            graph.get(a).add(b);
+        }
+
+        // dijkstra 수행
+        dijkstra(X);
+
+        PriorityQueue<Integer> pQ = new PriorityQueue<>();
+        for (int i = 1; i < distance.length; i++){
+            if (distance[i] == K)
+                pQ.add(i);
+        }
+
+
+        if (pQ.isEmpty())
+            System.out.println(-1);
+        else{
+            while(!pQ.isEmpty())
+                System.out.println(pQ.poll());
+        }
+    }
+
+
+    static void dijkstra(int X){            // 출발 노드
+        Queue<Integer> queue = new LinkedList<>();          // 탐색할 노드 삽입할 큐
+        queue.add(X);
+        visited[X] = true;
+
+        while(!queue.isEmpty()){
+            int curr = queue.poll();
+            for (int next : graph.get(curr)){
+                if(!visited[next]){
+                    distance[next] = Math.min(distance[next], distance[curr] + 1);
+                    visited[next] = true;
+                    queue.add(next);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제 및 유형
https://www.acmicpc.net/problem/18352

Dijkstra
## 풀이
간단한 다익스트라문제

시작 도시가 정해져있고, 주어진 최단거리와 일치하는 목적지를 찾아내면 된다.
모든 간선은 방향성이 있으며 가중치는 모두 1이다.

N까지의 2차원 배열을 ArrayList로 선언한다.
N이 300000까지 나올 수 있어서 2차원 배열은 불가능하다.
간선 정보를 받으며, 첫번째 수의 인덱스에 b를 추가한다.

### 다익스트라 수행
방문처리 할 boolean 배열을 선언하고, 출발도시를 Queue에 삽입 후 해당 도시를 방문처리하여 시작한다.
queue가 빌 때 까지 반복하며 다음을 수행한다.
- queue에서 원소를 꺼낸다.
- ArrayList 에서 해당 원소의 인덱스에 존재하는 수 중 아직 방문처리 하지 않은 원소만
현재 원소까지의 거리 + 1 | 해당 원소의 거리 중 최소값으로 갱신하고 queue에 삽입한다.
- 삽입한 원소는 방문처리한다.

이후 distance 배열을 순회하며 최단거리가 K인 원소만을 PriorityQueue 에 삽입, 오름차순으로 출력한다.

## 기록
- 다익스트라를 처음 풀어봐서 방문처리와 최소값 비교가 섞였다. 최소값 비교로만 했어도 더 직관적인 다익스트라 코드가 될 수 있다.
- 최소값이 갱신된 경우만 queue 에 삽입해도 될 것 같다.