### PR TITLE
9205. 맥주 마시면서 걸어가기

### DIFF
--- a/BOJ_JAVA/src/Main_9205.java
+++ b/BOJ_JAVA/src/Main_9205.java
@@ -1,0 +1,66 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+class Node{
+    int x;
+    int y;
+    public Node(int x, int y){
+        this.x = x;
+        this.y = y;
+    }
+}
+
+public class Main_9205 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int T = Integer.parseInt(br.readLine());
+        for (int t = 0; t < T; t++){
+            int N = Integer.parseInt(br.readLine());
+
+            Node[] allNodes = new Node[N+2];        // 모든 요소 저장할 배열
+            int[][] needBeers = new int[N+2][N+2];        // 노드 별 필요한 맥주 개수 저장할 배열
+            boolean[] visited = new boolean[N+2];   // 방문처리할 배열
+
+            st = new StringTokenizer(br.readLine());
+            allNodes[0] = new Node(Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken()));       // 집 위치 저장
+
+            for (int n = 1; n <= N+1; n++){
+                st = new StringTokenizer(br.readLine());
+                allNodes[n] = new Node(Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken()));     // 노드 위치 저장
+
+                for (int i = 0; i <= n; i++){               // 지금까지 저장된 노드들과 현재 추가된 노드 사이의 맥주 개수 구해서 2차원 배열에 저장
+                    int distance = Math.abs(allNodes[i].x - allNodes[n].x) + Math.abs(allNodes[i].y - allNodes[n].y);
+                    int bear = (int)Math.ceil((distance / 50.0));
+                    bear = bear > 20 ? -1 : bear;           // 만약 맥주가 20개가 넘으면 -1 저장
+                    needBeers[i][n] = bear;
+                    needBeers[n][i] = bear;
+                }
+            }
+
+            // BFS
+            Queue<Integer> queue = new LinkedList<>();      // 방문할 노드 저장할 queue
+            queue.add(0);   // 집 방문
+            visited[0] = true;
+
+            while(!queue.isEmpty()){
+                int nodeIndex = queue.poll();
+                for (int i = 1; i < allNodes.length; i++){
+                    if (!visited[i] && needBeers[nodeIndex][i] >= 0){           // 아직 방문하지 않았고, 맥주의 개수가 0 ~ 20 사이면 queue 에 저장
+                        queue.add(i);
+                        visited[i] = true;
+                    }
+                }
+            }
+
+            String result = "";
+            result = visited[N+1] == true ? "happy" : "sad";
+            System.out.println(result);
+        }
+    }
+}


### PR DESCRIPTION
## 문제 및 유형
https://www.acmicpc.net/problem/9205

BFS
## 풀이
조건
- 50미터에 맥주 1병을 소모한다.
- 맥주는 최대 20병을 소지할 수 있다.
- 편의점을 들러서 맥주를 충전할 수 있다. (최대 20병)

즉, 편의점이 하나도 주어지지 않는다면 최대 1000 미터를 이동할 수 있다.
편의점에 들린 후에도 최대 1000미터를 이동할 수 있다.

주어진 문제에서는 최단 거리를 구하는 것이 아닌, 단순히 도착 가능 여부를 판별하는 문제이므로 Queue 를 사용한 BFS 를 수행한다.

좌표간의 거리 / 50 = 맥주의 개수이며, 이는 좌표간의 비용을 의미한다.
모든 노드 (집, 편의점들, 목적지) 의 좌표와 각 좌표간의 비용을 계산하여 2차원 배열에 저장한다.
만약 비용이 20을 초과하면 -1을 저장한다.

### BFS
1. 출발지부터 Queue에 삽입 후 방문처리한다.
2. queue에서 노드를 하나씩 꺼내어 인접한 좌표를 탐색한다.
3. 인접한 좌표까지의 비용이 -1이 아니고, 아직 방문하지 않았다면 queue에 삽입한다.
4. queue에 삽입한 노드는 방문처리한다.

BFS 수행 이후 목적지점의 방문 여부가 true 라면 happy를, 
false 라면 sad 를 출력한다.

## 기록
- 50으로 나눈 몫이 소수점일 가능성이 있다. 이 때 auto casting 하게 되면 20.1 병이 필요할 경우 20으로 처리되어 오답이 나올 수 있으니 주의해야한다.