### PR TITLE
17298. 오큰수

### DIFF
--- a/BOJ_JAVA/src/Main_17298.java
+++ b/BOJ_JAVA/src/Main_17298.java
@@ -1,38 +1,47 @@
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.util.Stack;
 import java.util.StringTokenizer;
+
+class Pair{
+    int num;
+    int index;
+
+    public Pair(int num, int index){
+        this.num = num;
+        this.index = index;
+    }
+}
 
 public class Main_17298 {
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
         StringTokenizer st;
 
         int N = Integer.parseInt(br.readLine());
-        int[] arr = new int[N];
+        int[] result = new int[N];
+        Stack<Pair> stack = new Stack<>();               // 입력된 수 중 오큰수를 발견하지 못한 수 저장할 stack
 
         st = new StringTokenizer(br.readLine());
-        for (int n = 0; n < N; n++)
-            arr[n] = Integer.parseInt(st.nextToken());
 
-        Stack<Integer> stack = new Stack<>();
-        for (int n = 0; n < N; n++)
-            stack.push(arr[n]);
-
-        int[] result = new int[N];
-
-        for (int n = 0; n < N; n++){
-            int target = arr[n];
-
-
-            if (stack.empty())
-                result[n] = -1;
-            else
-                result[n] = stack.pop();
+        int idx = 0;
+        stack.push(new Pair(Integer.parseInt(st.nextToken()), idx++));      // 처음 수 stack 에 삽입
+        while(st.hasMoreTokens()){
+            int n = Integer.parseInt(st.nextToken());
+            while(!stack.empty()){
+                if(stack.peek().num < n)        // stack 의 top 이 n 보다 작으면
+                    result[stack.pop().index] = n;    // pop 한 후 해당 수의 오큰수를 n 으로 저장
+                else
+                    break;
+            }
+            stack.push(new Pair(n, idx++));
         }
 
-        for (int r : result)
-            System.out.print(r + " ");
+        for (int r : result) {
+            r = r == 0 ? -1 : r;
+            bw.write(r + " ");
+        }
+        bw.flush();
+        bw.close();
     }
 }


### PR DESCRIPTION
## 문제 및 유형
https://www.acmicpc.net/problem/17298

Stack
## 풀이
어떤 수의 오른쪽에 위치하면서, 해당 수보다 큰 첫번째 수를 찾는다.
Stack을 사용하여 간단하게 풀 수 있다.

어떤 수의 오큰수를 찾기 위해서는 해당 수의 이후에 들어오는 수를 바라보아야 한다.
따라서, stack에 수를 삽입하면서 stack의 top에 있는 수의 오큰수를 찾는다.
오큰수를 찾은 수는 stack에서 삭제하고 더이상 오큰수를 찾을 수 없으면 입력된 수를 stack에 삽입한다.
결과적으로 stack에는 오큰수를 찾지 못한 수가 내림차순으로 정렬된다.

예시 : A = [3, 5, 2, 7, 5, 6]

1. 3 입력
<img width="1180" alt="image" src="https://github.com/wynter122/Algorithm/assets/72314987/fc6d7023-4e11-4c75-b926-df66fe31d630">

stack이 비었으므로 3을 삽입한다.

3. 5 입력
<img width="1180" alt="image" src="https://github.com/wynter122/Algorithm/assets/72314987/7387b9a9-97ed-47ea-ab7d-c99409b92461">

stack의 top 인 3 < 5 이므로 3의 결과에 5를 저장한다.
3을 pop 하고 5를 삽입한다.

5. 2 입력
<img width="1180" alt="image" src="https://github.com/wynter122/Algorithm/assets/72314987/21790452-8f2a-4870-857a-0481a54241f7">

stack의 top 인 5 > 2 이므로 바로 2를 삽입한다.

7. 7 입력
<img width="1180" alt="image" src="https://github.com/wynter122/Algorithm/assets/72314987/ff27cdfb-66c9-4511-a861-7eba889c1c9f">

stack의 top인 2 < 7 이므로 2의 결과에 7을 저장한다.
2를 pop 한뒤 새로운 top인 5 <7 이므로 5의 결과에 7을 저장한다.
더이상 stack에 남은 수가 없으니 7을 삽입한다.

8. 5 입력
<img width="1180" alt="image" src="https://github.com/wynter122/Algorithm/assets/72314987/cce234e3-e152-44a5-8b5f-bd7af91879bd">

stack의 top인 7 > 5 이므로 바로 5를 삽입한다.

10. 6 입력
<img width="1180" alt="image" src="https://github.com/wynter122/Algorithm/assets/72314987/a6e3450f-5164-4add-b56a-2c46b3f5e78a">

stack의 top인 5 < 6 이므로 5의 결과에 6을 저장한다.
5를 pop 한 뒤, 새로운 top인 7 > 6 이므로 6을 삽입한다.

11. stack clear
<img width="1180" alt="image" src="https://github.com/wynter122/Algorithm/assets/72314987/68574909-9a2a-4f9e-bab9-63418dcbf88b">

최종적으로 stack에는 오큰수를 찾지 못한 수들이 내림차순으로 정렬되어있다.
stack을 하나씩 pop 하며 해당 수의 결과에 -1을 저장한 뒤 결과 배열을 출력한다.

시간복잡도는 O(N)이다.

## 기록
- 수를 Stack에 삽입할 때, 해당 수의 인덱스를 기억해야하니 객체를 생성하여 삽입하면 좋다.
