### PR TITLE
14284. 간선 이어가기

### DIFF
--- a/BOJ_JAVA/src/Main_14284.java
+++ b/BOJ_JAVA/src/Main_14284.java
@@ -1,0 +1,85 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+class Edge implements Comparable<Edge>{
+    int num;
+    int weight;
+    public Edge(int num, int weight){
+        this.num = num;
+        this.weight = weight;
+    }
+
+    @Override
+    public int compareTo(Edge edge){
+        if (this.weight > edge.weight)
+            return 1;
+        else if (this.weight < edge.weight)
+            return -1;
+        return 0;
+    }
+}
+public class Main_14284 {
+    static List<ArrayList<Edge>> graph = new ArrayList<>();
+    static boolean[] visited;
+    static int[] cost;
+    static int INF = 1000000;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        // 그래프 초기화
+        visited = new boolean[N+1];
+        cost = new int[N+1];
+        for (int n = 0; n <= N; n++){
+            graph.add(n, new ArrayList<>());
+            cost[n] = INF;
+        }
+
+
+        // 간선 정보 받기
+        for (int m = 0; m < M; m++){
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            int w = Integer.parseInt(st.nextToken());
+
+            graph.get(a).add(new Edge(b, w));
+            graph.get(b).add(new Edge(a, w));
+        }
+
+        // s, t 받기
+        st = new StringTokenizer(br.readLine());
+        int s = Integer.parseInt(st.nextToken());
+        int t = Integer.parseInt(st.nextToken());
+
+        // dijkstra 수행
+        dijkstra(s, t);
+
+        System.out.println(cost[t]);
+    }
+    static void dijkstra(int s, int t){
+        PriorityQueue<Edge> queue = new PriorityQueue<>();          // 방문할 정점 넣을 큐
+        queue.add(new Edge(s, 0));
+        cost[s] = 0;        // 출발 정점의 비용 0
+
+        while(!queue.isEmpty()){
+            Edge curr = queue.poll();
+            if (visited[curr.num])
+                continue;
+            visited[curr.num] = true;                           // 방문처리
+            for (Edge next : graph.get(curr.num)){              // 현재 방문 노드의 인접 노드 탐색
+                int newWeight = curr.weight + next.weight;
+                if (cost[next.num] > newWeight) {
+                    cost[next.num] = newWeight;        // 인접노드의 비용 갱신
+                    queue.add(new Edge(next.num, newWeight));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제 및 유형
https://www.acmicpc.net/problem/14284

Dijkstra, Priority Queue
## 풀이
주어지는 간선 정보를 모두 받은 후 Dijkstra 를 수행하면 된다.

### Dijkstra
현재 방문한 노드에서 인접 노드들의 최소 비용을 탐색하는 알고리즘이다.
앞으로 방문해야할 노드 중 가장 최소 비용의 노드를 다음 방문 노드로 선택하므로 우선순위 큐를 사용한다.
시작 지점의 비용을 0으로 하여 우선순위 큐에 삽입 후 다음 과정을 반복한다.

1. 방문할 노드를 꺼내어 아직 방문하지 않은 노드인지 확인한다.
2. 방문하지 않았다면 방문처리 후, 인접한 노드들을 탐색한다.
3. 인접 노드의 현재 비용 > 현재 노드의 비용 + 인접노드까지의 가중치 를 만족한다면 최소 비용으로 갱신한다.
4. 인접 노드의 번호와 새로운 최소비용을 객체로 묶어 큐에 삽입한다.

3개의 노드가 있고, 아래와 같이 연결된 그래프의 다익스트라 수행 과정이다.

<img width="857" alt="image" src="https://github.com/wynter122/Algorithm/assets/72314987/88c184da-6431-4f1e-94fe-4fe3eb1d4a00">

우선순위 큐에 <노드번호 1, 비용 0> 을 삽입하여 다익스트라를 수행한다.

<img width="856" alt="image" src="https://github.com/wynter122/Algorithm/assets/72314987/8bba8ec4-2bd4-4350-9575-fed7ea6c4bac">

1의 비용을 0으로 저장하고, 1과 인접한 노드 2, 3의 최소 비용을 갱신한다.
<2, 1> <3, 3> 을 우선순위 큐에 삽입한다.

우선순위 큐 조건에 따라 2를 먼저 방문한다.

<img width="844" alt="image" src="https://github.com/wynter122/Algorithm/assets/72314987/ec24558d-3135-4c55-86c4-c6b4d8c2cfa9">

2에 인접한 노드 중, 방문하지 않은 노드는 3이다.
3의 현재 비용 = 3
2의 비용 + 2->3 까지의 가중치 = 2 이므로, 3의 최소비용을 2로 갱신한다.
<3, 2> 를 우선순위 큐에 삽입한다.

<3, 3>, <3, 2> 중 <3, 2> 의 비용이 더 적으므로 다음으로 방문한다.
<img width="881" alt="image" src="https://github.com/wynter122/Algorithm/assets/72314987/042d5658-e6a7-49c1-b721-11bb0b8e64eb">

더이상 방문할 노드가 없으므로 <3, 3>을 방문한다.
동일하게 더이상 방문할 노드가 없고 queue 가 비었으니 다익스트라를 종료한다.


다익스트라 수행 이후 t의 cost를 출력한다.

## 기록
- 문제에서 "s와 t가 연결이 되는 시점의 간선의 가중치의 합이 최소가 되게 추가하는 간선의 순서를 조정할 때, 그 최솟값을 구하시오" 라고 되어있어, s, t가 가장 처음 연결되는 시점에서의 최소비용이라고 생각할 수 있다. 그게 아니고 그냥 최종적으로 s, t 연결의 최소 비용을 구하는 다익스트라를 수행하면 된다.
- 방문처리 대신, "인접노드의 현재 비용 > 현재노드의 최소 비용 + 인접노드까지의 가중치" 로 갱신 및 큐 삽입 조건을 대신할 수 있다.
- 객체를 우선순위 큐에 사용하기 위해서, Comparable 인터페이스를 오버라이드하여 구현해야한다.