### PR TITLE
17299. 오등큰수

### DIFF
--- a/BOJ_JAVA/src/Main_17299.java
+++ b/BOJ_JAVA/src/Main_17299.java
@@ -1,0 +1,60 @@
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Stack;
+import java.util.StringTokenizer;
+
+class Element{
+    int idx;
+    int num;
+    int cnt;
+    public Element(int idx, int num, int cnt){
+        this.idx = idx;
+        this.num = num;
+        this.cnt = cnt;
+    }
+}
+
+public class Main_17299 {
+    static int[] counter = new int[1000001];                // 원소의 등장 횟수 담을 배열
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st;
+
+        int N = Integer.parseInt(br.readLine());
+        st = new StringTokenizer(br.readLine());
+
+        ArrayList<Element> arrayList = new ArrayList<>();           // 수열 입력 받으면서 원소 등장횟수 파악
+        int i = 0;
+        while(st.hasMoreTokens()){
+            int n = Integer.parseInt(st.nextToken());
+            counter[n]++;
+            arrayList.add(new Element(i++, n, 0));
+        }
+
+        int[] result = new int[N];
+        Stack<Element> stack = new Stack<>();                       // 원소 담을 stack
+        for (Element ele : arrayList) {
+            ele.cnt = counter[ele.num];                     // 카운트 갱신
+            if (!stack.isEmpty()) {
+                while (!stack.isEmpty()) {
+                    Element top = stack.peek();                         // stack 의 탑에 있는 원소
+                    if (top.cnt >= ele.cnt)                             // 현재 원소의 cnt 보다 크거나 같으면 break
+                        break;
+
+                    result[top.idx] = ele.num;                          // 현재 원소의 cnt 보다 작으면 : 현재 원소 값을 결과 배열의 top 의 인덱스에 삽입
+                    stack.pop();
+                }
+            }
+            stack.add(ele);
+        }
+
+        while(!stack.isEmpty())
+            result[stack.pop().idx] = -1;
+
+        for (int r : result)
+            bw.write(r + " ");
+        bw.flush();
+        bw.close();
+    }
+}


### PR DESCRIPTION
## 문제 및 유형
https://www.acmicpc.net/problem/17299

Stack
## 풀이
수열의 각 원소의
1. 등장 이후 가장 처음 등장하며
2. 수열에서 등장한 횟수가 원소보다 더 큰 수
를 찾는다.

먼저 각 수를 입력받으며 등장횟수를 파악한다. (수를 인덱스로 하여 카운트 증가)
수는 <수열에서의 인덱스, 값, 카운터> 를 객체화하여 ArrayList에 삽입한다.

ArrayList 를 순회하며 Stack에 값을 넣고 다음 과정을 반복한다.
- Stack의 top에 있는 수의 counter 와 현재 수의 counter를 비교한다
- top' counter < curr' counter 라면 top의 인덱스에 현재 수의 값을 기록하고 pop 한다
- top' counter >= curr' counter 이거나, stack이 빌 때 까지 위 두 과정을 반복한다
- 현재 수를 stack에 삽입한다.

위 과정이 모두 끝나면 Stack에는 **오등큰수가 없는 수가 Counter 내림차순**으로 남게된다.
Stack을 하나씩 비우면서 인덱스에 -1을 기록한다.

## 기록
참고 : #18
오큰수문제에서 값이 아닌 해당 값의 카운트를 비교하는식으로 바꾸면 쉽게 해결할 수 있다.