### PR TITLE
11909. 배열 탈출

### DIFF
--- a/BOJ_JAVA/src/Main_11909.java
+++ b/BOJ_JAVA/src/Main_11909.java
@@ -1,0 +1,88 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+class Node implements Comparable<Node> {
+    int x, y;
+    int cost;
+
+    public Node(int x, int y, int cost){
+        this.x = x;
+        this.y = y;
+        this.cost = cost;
+    }
+
+    @Override
+    public int compareTo(Node node){
+        if (this.cost > node.cost)
+            return 1;
+        else if (this.cost < node.cost)
+            return -1;
+        return 0;
+    }
+}
+
+public class Main_11909 {
+    static int[][] graph;
+    static int[][] cost;
+    static boolean[][] visited;
+    static final int INF = 100000000;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int N = Integer.parseInt(br.readLine());
+
+        graph = new int[N+1][N+1];
+        cost = new int[N+1][N+1];
+        visited = new boolean[N+1][N+1];
+        for (int n = 0; n <= N; n++){
+            Arrays.fill(cost[n], INF);
+        }
+        for (int i = 1; i <= N; i++){
+            st = new StringTokenizer(br.readLine());
+            for (int j = 1; j <= N; j++)
+                graph[i][j] = Integer.parseInt(st.nextToken());
+        }
+
+        // Dijkstra
+        dijkstra(N);
+
+        System.out.println(cost[1][1]);
+
+    }
+
+    static void dijkstra(int N){
+        PriorityQueue<Node> queue = new PriorityQueue();
+        queue.add(new Node(N, N, 0));
+
+        while(!queue.isEmpty()){
+            Node curr = queue.poll();
+            if (visited[curr.x][curr.y])
+                continue;
+
+            cost[curr.x][curr.y] = curr.cost > cost[curr.x][curr.y] ? cost[curr.x][curr.y] : curr.cost;     // 최소비용 갱신
+            visited[curr.x][curr.y] = true;
+
+            if (curr.x >= 1 && curr.y > 1){                    // i == n -> A[i][j+1]
+                int next = graph[curr.x][curr.y-1] - graph[curr.x][curr.y] - 1;
+                if (next > 0)
+                    next = 0;
+                if (!visited[curr.x][curr.y-1])
+                    queue.add(new Node(curr.x, curr.y-1, curr.cost + Math.abs(next)));
+            }
+
+            if (curr.x > 1 && curr.y >= 1){                    // j == n -> A[i+1][j]
+                int next = graph[curr.x-1][curr.y] - graph[curr.x][curr.y] - 1;
+                if (next > 0)
+                    next = 0;
+                if (!visited[curr.x-1][curr.y])
+                    queue.add(new Node(curr.x-1, curr.y, curr.cost + Math.abs(next)));
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
## 문제 및 유형
https://www.acmicpc.net/problem/11909

Dijkstra
## 풀이
조건
- 우 또는 하 방향으로만 1칸씩 이동이 가능하다
- 현재 칸의 값보다 작은 칸으로만 이동 가능하다
- 비용 1을 들여 현재 칸의 값을 1씩 증가시킬 수 있다

최소 비용으로 목적지에 도착하기 위해 Dijkstra (BFS) 로 풀 수 있다.

가장 비용이 적은 인접 노드를 방문하기 위해 우선 순위 큐 선언한다
큐에 시작 노드의 위치와 비용을 0으로 설정해 삽입한다

- 큐에서 방문할 노드를 꺼낸다. 이 노드는 가장 비용이 적은 노드가 된다.
- 아직 방문하지 않은 노드이며, 현재 비용이 이전에 탐색된 비용보다 작다면 최소비용으로 갱신한다
- 방문처리 후, 오른쪽, 아래 노드를 탐색한다.
- 아직 방문하지 않은 노드 중, 현재 노드의 비용 + | 다음 노드의 값 -  현재 노드 값 | 을 포함해 큐에 삽입한다.

위 과정을 반복한 후, 목적지의 비용을 출력한다.

## 기록
