### PR TITLE
1939. 중량제한

### DIFF
--- a/BOJ_JAVA/src/Main_1939.java
+++ b/BOJ_JAVA/src/Main_1939.java
@@ -1,0 +1,97 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+class Edge implements Comparable<Edge>{
+    int vertex;
+    int weight;
+
+    public Edge(int vertex, int weight){
+        this.vertex = vertex;
+        this.weight = weight;
+    }
+
+    @Override
+    public int compareTo(Edge edge){
+        if (this.weight > edge.weight)
+            return -1;
+        else if (this.weight < edge.weight)
+            return 1;
+        return 0;
+    }
+}
+
+public class Main_1939 {
+    static ArrayList<ArrayList<Edge>> graph = new ArrayList<>();
+    static int[] cost;
+    static int INF = 2000000000;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        // init graph
+        for (int n = 0; n <= N; n++)
+            graph.add(n, new ArrayList<>());
+        cost = new int[N+1];
+
+        // edge info
+        for (int m = 0; m < M; m++){
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+
+            graph.get(a).add(new Edge(b, c));
+            graph.get(b).add(new Edge(a, c));
+        }
+
+        st = new StringTokenizer(br.readLine());
+        int S = Integer.parseInt(st.nextToken());           // start
+        int T = Integer.parseInt(st.nextToken());           // end
+
+        BFS(S, T, N);
+
+        System.out.println(cost[T]);
+    }
+
+    static void BFS(int S, int T, int N){
+        boolean[] visited = new boolean[N+1];
+
+        PriorityQueue<Edge> queue = new PriorityQueue<>();
+        queue.add(new Edge(S, INF));
+        while(!queue.isEmpty()){
+            Edge curr = queue.poll();
+            if (visited[curr.vertex])
+                continue;
+
+            visited[curr.vertex] = true;
+            cost[curr.vertex] = curr.weight;
+            for (Edge next : graph.get(curr.vertex)){
+                if (!visited[next.vertex] && cost[next.vertex] < next.weight){
+                    int w = Math.min(curr.weight, next.weight);
+                    queue.add(new Edge(next.vertex, w));
+                }
+            }
+        }
+    }
+}
+
+/*
+5 7
+1 2 1
+2 5 1
+1 3 2
+1 5 4
+3 5 2
+3 4 3
+4 5 4
+1 5
+ */


### PR DESCRIPTION
## 문제 및 유형
https://www.acmicpc.net/problem/1939

BFS
## 풀이
시작 정점부터 끝 정점까지 최대 비용으로 연결하는 루트를 찾는다.
이후, 연결된 간선들 중 최소값을 구해 출력한다.

최대 가중치를 가진 간선을 고르기 위해 우선순위 큐를 선언한다.
큐에 시작 정점을 삽입하여 BFS를 시작한다.

- 큐에서 방문할 노드를 꺼낸다.
- 방문하지 않았다면, 방문처리 후 현재 정점이 연결된 가중치를 저장한다.
- 인접한 노드를 탐색하며 방문하지 않았고, 다음 정점까지 이미 검색된 가중치 < 현재 정점에서 연결했을때 가중치 인 경우 큐에 삽입한다.
위 과정을 반복한다.

다음 정점까지 이미 검색된 가중치보다, 새로운 가중치가 같거나 클 때만 이동하는것이 이득이다.

마지막으로, 탐색된 가중치들 중 최소값이 가능한 중량의 최대값이므로 출력한다.

## 기록
Prim 알고리즘 같다